### PR TITLE
Add optional image

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,8 @@ You can download fontawesome [here](https://fontawesome.com/download).
 ```
 ### Image
 
-To add an image to your curriculum vitae, you can a path to that image to the `image-path` parameter (the path should be from the rrot of your project and start with a `/`). Here are te additional parameters:
+To add an image to your curriculum vitae, you can a path to that image to the `image-path` parameter (the path should be from the root of your project and start with a `/`). Here are the additional parameters:
+
 - `image-height`: size of the image
 - `image-frame-stroke`: stroke of the frame. By default is 1pt + the main of the file. Can be any stroke value. Set to `none` to remove the frame.
 

--- a/README.md
+++ b/README.md
@@ -44,11 +44,17 @@ You can download fontawesome [here](https://fontawesome.com/download).
     // custom socials: (icon, link, body)
     // any fontawesome icon can be used: https://fontawesome.com/search
     website: ("link", "https://example.me", "example.me"),
+    image-path: "/my-image.png",
   ),
 )
 
 // ...
 ```
+### Image
+
+To add an image to your curriculum vitae, you can a path to that image to the `image-path` parameter (the path should be from the rrot of your project and start with a `/`). Here are te additional parameters:
+- `image-height`: size of the image
+- `image-frame-stroke`: stroke of the frame. By default is 1pt + the main of the file. Can be any stroke value. Set to `none` to remove the frame.
 
 ## Examples
 

--- a/lib.typ
+++ b/lib.typ
@@ -15,6 +15,10 @@
 #let _header(
   title: [],
   subtitle: [],
+  image-path: none,
+  image-height: none,
+  image-frame-stroke: auto,
+  color: moderncv-blue,
   socials: (:),
 ) = {
   let titleStack = stack(
@@ -68,6 +72,41 @@
     ..socialsList,
   )
 
+  let imageStack = []
+  
+  if image-path != none {
+    let image = image(image-path, height: image-height)
+
+    let imageFramed = []
+
+    if image-frame-stroke == none { // no frame
+      imageFramed = image
+    } else {
+      if image-frame-stroke == auto { // default stroke
+        image-frame-stroke = 1pt + color 
+      } else { 
+        image-frame-stroke = stroke(image-frame-stroke)
+        if image-frame-stroke.paint == auto { // use the main color by default
+          image-frame-stroke = stroke((
+            paint:color, 
+            thickness:image-frame-stroke.thickness,
+            cap:image-frame-stroke.cap,
+            join:image-frame-stroke.join,
+            dash:image-frame-stroke.dash,
+            miter-limit:image-frame-stroke.miter-limit
+          ))
+        }
+      }
+      imageFramed = rect(image, stroke:image-frame-stroke)
+    }
+
+    imageStack = stack(
+      dir: ltr,
+      h(1em),
+      imageFramed
+    )
+  }
+
   stack(
     dir: ltr,
     titleStack,
@@ -75,6 +114,7 @@
       right + top,
       socialStack,
     ),
+    imageStack,
   )
 }
 
@@ -85,6 +125,9 @@
   color: moderncv-blue,
   lang: "en",
   font: ("New Computer Modern"),
+  image-path: none,
+  image-height: 8em,
+  image-frame-stroke: auto,
   show-footer: true,
   body,
 ) = [
@@ -121,7 +164,12 @@
     )
   }
 
-  #_header(title: name, subtitle: subtitle, socials: social)
+  #_header(
+    title: name, subtitle: subtitle,
+    image-path: image-path, image-height: image-height, image-frame-stroke: image-frame-stroke,
+    color:color,
+    socials: social
+  )
 
   #body
 

--- a/lib.typ
+++ b/lib.typ
@@ -87,6 +87,7 @@
       } else { 
         image-frame-stroke = stroke(image-frame-stroke)
         if image-frame-stroke.paint == auto { // use the main color by default
+          // fields on stroke are not yet mutable
           image-frame-stroke = stroke((
             paint:color, 
             thickness:image-frame-stroke.thickness,

--- a/lib.typ
+++ b/lib.typ
@@ -73,38 +73,41 @@
   )
 
   let imageStack = []
-  
+
   if image-path != none {
     let image = image(image-path, height: image-height)
 
     let imageFramed = []
 
-    if image-frame-stroke == none { // no frame
+    if image-frame-stroke == none {
+      // no frame
       imageFramed = image
     } else {
-      if image-frame-stroke == auto { // default stroke
-        image-frame-stroke = 1pt + color 
-      } else { 
+      if image-frame-stroke == auto {
+        // default stroke
+        image-frame-stroke = 1pt + color
+      } else {
         image-frame-stroke = stroke(image-frame-stroke)
-        if image-frame-stroke.paint == auto { // use the main color by default
+        if image-frame-stroke.paint == auto {
+          // use the main color by default
           // fields on stroke are not yet mutable
           image-frame-stroke = stroke((
-            paint:color, 
-            thickness:image-frame-stroke.thickness,
-            cap:image-frame-stroke.cap,
-            join:image-frame-stroke.join,
-            dash:image-frame-stroke.dash,
-            miter-limit:image-frame-stroke.miter-limit
+            paint: color,
+            thickness: image-frame-stroke.thickness,
+            cap: image-frame-stroke.cap,
+            join: image-frame-stroke.join,
+            dash: image-frame-stroke.dash,
+            miter-limit: image-frame-stroke.miter-limit,
           ))
         }
       }
-      imageFramed = rect(image, stroke:image-frame-stroke)
+      imageFramed = rect(image, stroke: image-frame-stroke)
     }
 
     imageStack = stack(
       dir: ltr,
       h(1em),
-      imageFramed
+      imageFramed,
     )
   }
 
@@ -125,7 +128,7 @@
   social: (:),
   color: moderncv-blue,
   lang: "en",
-  font: ("New Computer Modern"),
+  font: "New Computer Modern",
   image-path: none,
   image-height: 8em,
   image-frame-stroke: auto,
@@ -166,10 +169,13 @@
   }
 
   #_header(
-    title: name, subtitle: subtitle,
-    image-path: image-path, image-height: image-height, image-frame-stroke: image-frame-stroke,
-    color:color,
-    socials: social
+    title: name,
+    subtitle: subtitle,
+    image-path: image-path,
+    image-height: image-height,
+    image-frame-stroke: image-frame-stroke,
+    color: color,
+    socials: social,
   )
 
   #body


### PR DESCRIPTION
The LaTeX package moderncv allows to have a framed imaged on the right hand side of the header. This PR introduces this possibility in this template.

One can specify a path for the image, its height (by defaut 8em) and its frame (by default 1pt + the color).

The frame can be set to none and completely removed or set to any stroke value. If the color is not specified, the main color of the template will be used.