### PR TITLE
Pass image instead of path and height

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ You can download fontawesome [here](https://fontawesome.com/download).
     // custom socials: (icon, link, body)
     // any fontawesome icon can be used: https://fontawesome.com/search
     website: ("link", "https://example.me", "example.me"),
-    image-path: "/my-image.png",
   ),
+  image: image("my-image.png", height: 8em),
 )
 
 // ...
@@ -53,9 +53,8 @@ You can download fontawesome [here](https://fontawesome.com/download).
 
 ### Image
 
-To add an image to your curriculum vitae, you can a path to that image to the `image-path` parameter (the path should be from the root of your project and start with a `/`). Here are the additional parameters:
+To add an image to your curriculum vitae, you can pass an [image](https://typst.app/docs/reference/visualize/image/) to the `image` parameter. Here are the additional parameters:
 
-- `image-height`: size of the image
 - `image-frame-stroke`: stroke of the frame. By default is 1pt + the main of the file. Can be any stroke value. Set to `none` to remove the frame.
 
 ## Examples

--- a/lib.typ
+++ b/lib.typ
@@ -15,8 +15,7 @@
 #let _header(
   title: [],
   subtitle: [],
-  image-path: none,
-  image-height: none,
+  image: none,
   image-frame-stroke: auto,
   color: moderncv-blue,
   socials: (:),
@@ -74,8 +73,7 @@
 
   let imageStack = []
 
-  if image-path != none {
-    let image = image(image-path, height: image-height)
+  if image != none {
 
     let imageFramed = []
 
@@ -129,8 +127,7 @@
   color: moderncv-blue,
   lang: "en",
   font: "New Computer Modern",
-  image-path: none,
-  image-height: 8em,
+  image: none,
   image-frame-stroke: auto,
   paper: "a4",
   margin: (
@@ -173,8 +170,7 @@
   #_header(
     title: name,
     subtitle: subtitle,
-    image-path: image-path,
-    image-height: image-height,
+    image: image,
     image-frame-stroke: image-frame-stroke,
     color: color,
     socials: social,


### PR DESCRIPTION
Thanks for the template! I wanted to try the recently added feature of adding an image (thanks @Orbion-J!), but struggled with including the image. It seems like typst searches for the image in the directory of moderner-cv, instead of the directory of the project, which uses moderner-cv. I get the following error:
```
error: file not found (searched at /home/lampert/.cache/typst/packages/preview/moderner-cv/0.1.2/picture.jpg)
   ┌─ @preview/moderner-cv:0.1.2/lib.typ:78:22
   │
78 │     let image = image(image-path, height: image-height)
   │                       ^^^^^^^^^^
```
Obviously, I don't want to put my image into this specific path, but rather in my project dir. Therefore, I propose to pass an `image` object instead of only the path. This also makes the `image-height` parameter obsolete as it is passed to the `image` function, which the user is now supposed to call.
What do you think?