### PR TITLE
Add a homepage link to socials

### DIFF
--- a/lib.typ
+++ b/lib.typ
@@ -41,6 +41,7 @@
     email: ("envelope", "mailto:"),
     github: ("github", "https://github.com/"),
     linkedin: ("linkedin", "https://linkedin.com/in/"),
+    homepage: ("link", "https://"),
     x: ("x-twitter", "https://twitter.com/"),
     bluesky: ("bluesky", "https://bsky.app/profile/"),
   )


### PR DESCRIPTION
Example: 
![image](https://github.com/user-attachments/assets/a55782cc-9415-4c7e-ab70-584ffa5f4fc9)
