### PR TITLE
feat: load resumes from JSON Resume via @preview/gairm-import

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,10 @@ jobs:
           if-no-files-found: error
       - name: Compile thumbnail
         run: pixi run compile-thumbnail
+      - name: Compile JSON Resume smoke test
+        run: pixi run test-json-resume
+      - name: Compile JSON Resume helper unit tests
+        run: pixi run test-helpers
       - name: Verify git status is clean
         run: |
           git checkout -- template/cv.typ

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,10 +34,6 @@ jobs:
           if-no-files-found: error
       - name: Compile thumbnail
         run: pixi run compile-thumbnail
-      - name: Compile JSON Resume smoke test
-        run: pixi run test-json-resume
-      - name: Compile JSON Resume helper unit tests
-        run: pixi run test-helpers
       - name: Verify git status is clean
         run: |
           git checkout -- template/cv.typ

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ For finer control — overriding a single header field, stitching in custom sect
 // ...
 ```
 
-Validation and the `basics → social` remap go through [`@preview/gairm-import`](https://typst.app/universe/package/gairm-import), so a malformed document aborts the compile with a combined error report rather than failing later in the renderer.
+Validation goes through [`@preview/gairm-import`](https://typst.app/universe/package/gairm-import) — a malformed document aborts the compile with a combined error report rather than failing later in the renderer. The `basics → social` remap and the per-section body rendering live in this package (`internal/json-resume*.typ`).
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ For finer control — overriding a single header field, stitching in custom sect
 // ...
 ```
 
-Validation goes through [`@preview/gairm-import`](https://typst.app/universe/package/gairm-import) — a malformed document aborts the compile with a combined error report rather than failing later in the renderer. The `basics → social` remap and the per-section body rendering live in this package (`internal/json-resume*.typ`).
+Validation goes through [`@preview/gairm-import`](https://typst.app/universe/package/gairm-import) — a malformed document aborts compilation with a combined error report rather than failing later in the renderer. The `basics → social` remap and the per-section body rendering live in this package (`internal/json-resume*.typ`).
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,42 @@ To add an image to your curriculum vitae, you can pass an [image](https://typst.
 
 - `image-frame-stroke`: stroke of the frame. By default is 1pt + the main of the file. Can be any stroke value. Set to `none` to remove the frame.
 
+## Loading from a JSON Resume document
+
+If you already maintain your CV as a [JSON Resume](https://jsonresume.org/schema) `resume.json`, you can render it directly:
+
+```typst
+#import "@preview/moderner-cv:0.2.1": moderner-cv-from-json
+
+#moderner-cv-from-json(json("resume.json"))
+```
+
+Header overrides (e.g. `image:`, `subtitle:`, `lang:`) can be passed as named arguments and take precedence over what's inferred from `basics`:
+
+```typst
+#moderner-cv-from-json(
+  json("resume.json"),
+  image: image("me.png", height: 8em),
+  lang: "de",
+)
+```
+
+For finer control — overriding a single header field, stitching in custom sections, or skipping the built-in body layout — call `from-json-resume` directly:
+
+```typst
+#import "@preview/moderner-cv:0.2.1": *
+
+#let parts = from-json-resume(json("resume.json"))
+
+#show: moderner-cv.with(..parts.header)
+
+#parts.body
+= Custom Section
+// ...
+```
+
+Validation and the `basics → social` remap go through [`@preview/gairm-import`](https://typst.app/universe/package/gairm-import), so a malformed document aborts the compile with a combined error report rather than failing later in the renderer.
+
 ## Examples
 
 ![Jane Doe's CV](assets/thumbnail.png)

--- a/internal/json-resume-mapping.typ
+++ b/internal/json-resume-mapping.typ
@@ -2,14 +2,24 @@
 // shape `moderner-cv(...)` expects. No Typst content emitted here —
 // the rendering layer lives in `json-resume.typ`.
 
-// moderner-cv's predefined `social` keys. Anything else is emitted
-// as a custom 3-tuple `(faIcon, url, body)` so the link still renders.
-#let _known-social-keys = ("phone", "email", "github", "linkedin", "x", "bluesky")
+// moderner-cv's predefined `social` keys (mirroring _header's
+// socialsDict in lib.typ:67-75). `phone` and `email` are also
+// predefined slots but they're sourced from `basics.phone` /
+// `basics.email` — a profile carrying `network: "Phone"` would
+// silently clobber the basics-derived entry, so we route those to
+// custom-link instead of the predefined slot.
+#let _basics-owned-keys = ("phone", "email")
+#let _known-social-keys = ("github", "linkedin", "x", "bluesky")
 
-// FontAwesome guesses for networks not in the predefined set. Falls
-// back to a generic "link" icon; users who care can post-process the
-// returned dict before handing it to `moderner-cv`.
+// FontAwesome icons keyed by lowercased network name. Predefined
+// keys are included so a known-network profile that has only a URL
+// (and so can't take the username-shaped predefined path) still
+// renders with its proper brand icon via the custom 3-tuple fallback.
 #let _network-icon = (
+  github: "github",
+  linkedin: "linkedin",
+  x: "x-twitter",
+  bluesky: "bluesky",
   twitter: "x-twitter",
   mastodon: "mastodon",
   gitlab: "gitlab",
@@ -24,15 +34,18 @@
 )
 
 /// Map a JSON Resume `basics.profiles[]` entry to a moderner-cv
-/// `social` dict pair. Predefined keys (`github`, `linkedin`, …) get
-/// a bare username; everything else becomes a custom `(icon, url, body)`
-/// 3-tuple. Returns `none` when there's no usable destination.
+/// `social` dict pair. Predefined keys (`github`, `linkedin`, `x`,
+/// `bluesky`) get a bare username; everything else becomes a custom
+/// `(icon, url, body)` 3-tuple. Returns `none` when there's no
+/// usable destination, the network is empty, or the network names
+/// a basics-owned slot (phone/email) which would clobber.
 ///
 /// -> (str, any) | none
 #let _profile-to-social(profile) = {
   let network = profile.at("network", default: none)
   if network == none { return none }
   let key = lower(network)
+  if key == "" or key in _basics-owned-keys { return none }
   // Normalize twitter → x to match moderner-cv's predefined key.
   if key == "twitter" { key = "x" }
   let username = profile.at("username", default: none)
@@ -61,6 +74,8 @@
 /// Build the kwargs for `moderner-cv.with(...)` from JSON Resume
 /// `basics`. `basics.url` has no predefined slot in moderner-cv so it
 /// surfaces as a `website` custom-social with a generic link icon.
+/// First-wins for duplicate profile networks (so if a user lists both
+/// `Twitter` and `X`, the first one in document order takes the slot).
 ///
 /// -> dictionary
 #let basics-to-header(basics) = {
@@ -79,7 +94,9 @@
   if url != none { social.insert("website", ("link", url, url)) }
   for profile in basics.at("profiles", default: ()) {
     let entry = _profile-to-social(profile)
-    if entry != none { social.insert(entry.at(0), entry.at(1)) }
+    if entry != none and entry.at(0) not in social {
+      social.insert(entry.at(0), entry.at(1))
+    }
   }
   let addr = _location-to-address(basics.at("location", default: none))
   if addr != none { social.insert("address", addr) }

--- a/internal/json-resume-mapping.typ
+++ b/internal/json-resume-mapping.typ
@@ -1,0 +1,88 @@
+// Pure data → data mapping from a JSON Resume document to the dict
+// shape `moderner-cv(...)` expects. No Typst content emitted here —
+// the rendering layer lives in `json-resume.typ`.
+
+// moderner-cv's predefined `social` keys. Anything else is emitted
+// as a custom 3-tuple `(faIcon, url, body)` so the link still renders.
+#let _known-social-keys = ("phone", "email", "github", "linkedin", "x", "bluesky")
+
+// FontAwesome guesses for networks not in the predefined set. Falls
+// back to a generic "link" icon; users who care can post-process the
+// returned dict before handing it to `moderner-cv`.
+#let _network-icon = (
+  twitter: "x-twitter",
+  mastodon: "mastodon",
+  gitlab: "gitlab",
+  stackoverflow: "stack-overflow",
+  youtube: "youtube",
+  medium: "medium",
+  facebook: "facebook",
+  instagram: "instagram",
+  dribbble: "dribbble",
+  behance: "behance",
+  twitch: "twitch",
+)
+
+/// Map a JSON Resume `basics.profiles[]` entry to a moderner-cv
+/// `social` dict pair. Predefined keys (`github`, `linkedin`, …) get
+/// a bare username; everything else becomes a custom `(icon, url, body)`
+/// 3-tuple. Returns `none` when there's no usable destination.
+///
+/// -> (str, any) | none
+#let _profile-to-social(profile) = {
+  let network = profile.at("network", default: none)
+  if network == none { return none }
+  let key = lower(network)
+  // Normalize twitter → x to match moderner-cv's predefined key.
+  if key == "twitter" { key = "x" }
+  let username = profile.at("username", default: none)
+  let url = profile.at("url", default: none)
+  if key in _known-social-keys and username != none {
+    return (key, username)
+  }
+  // Custom social: needs a destination URL and a body to display.
+  let dest = if url != none { url } else { username }
+  if dest == none { return none }
+  let body = if username != none { username } else { url }
+  let icon = _network-icon.at(key, default: "link")
+  (key, (icon, dest, body))
+}
+
+#let _location-to-address(loc) = {
+  if loc == none { return none }
+  let parts = ()
+  for k in ("address", "postalCode", "city", "region", "countryCode") {
+    let v = loc.at(k, default: none)
+    if v != none and v != "" { parts.push(v) }
+  }
+  if parts.len() == 0 { none } else { parts.join(", ") }
+}
+
+/// Build the kwargs for `moderner-cv.with(...)` from JSON Resume
+/// `basics`. `basics.url` has no predefined slot in moderner-cv so it
+/// surfaces as a `website` custom-social with a generic link icon.
+///
+/// -> dictionary
+#let basics-to-header(basics) = {
+  let header = (:)
+  let name = basics.at("name", default: none)
+  if name != none { header.insert("name", name) }
+  let label = basics.at("label", default: none)
+  if label != none { header.insert("subtitle", label) }
+
+  let social = (:)
+  let phone = basics.at("phone", default: none)
+  if phone != none { social.insert("phone", phone) }
+  let email = basics.at("email", default: none)
+  if email != none { social.insert("email", email) }
+  let url = basics.at("url", default: none)
+  if url != none { social.insert("website", ("link", url, url)) }
+  for profile in basics.at("profiles", default: ()) {
+    let entry = _profile-to-social(profile)
+    if entry != none { social.insert(entry.at(0), entry.at(1)) }
+  }
+  let addr = _location-to-address(basics.at("location", default: none))
+  if addr != none { social.insert("address", addr) }
+  header.insert("social", social)
+  header
+}

--- a/internal/json-resume.typ
+++ b/internal/json-resume.typ
@@ -1,90 +1,13 @@
-// JSON Resume (https://jsonresume.org/schema) adapter for moderner-cv.
-// `from-json-resume` validates via @preview/gairm-import and remaps
-// to the dict shape `moderner-cv(...)` expects (header kwargs + body
-// content). The one-call `moderner-cv-from-json` wrapper lives in
-// `lib.typ`, where it can compose `moderner-cv` directly.
+// JSON Resume (https://jsonresume.org/schema) → moderner-cv adapter.
+// Header reshape lives in `json-resume-mapping.typ`; this file owns the
+// body rendering. `lib.typ` wraps both in a single one-call entry point.
 
 #import "@preview/gairm-import:0.8.1": parse as _parse, resume-schema-strict
+#import "json-resume-mapping.typ": basics-to-header
 
 // Renderer helpers (`cv-entry`, `cv-line`, …) are passed in by the
 // caller in `lib.typ` to avoid a cyclic `#import "../lib.typ"` —
 // `lib.typ` re-exports `from-json-resume` from this file.
-
-// moderner-cv's predefined `social` keys. Anything else is emitted
-// as a custom 3-tuple `(faIcon, url, body)` so the link still renders.
-#let _known-social-keys = ("phone", "email", "github", "linkedin", "x", "bluesky")
-
-// FontAwesome guesses for networks not in the predefined set. Falls
-// back to a generic "link" icon; users who care can post-process the
-// returned dict before handing it to `moderner-cv`.
-#let _network-icon = (
-  twitter: "x-twitter",
-  mastodon: "mastodon",
-  gitlab: "gitlab",
-  stackoverflow: "stack-overflow",
-  youtube: "youtube",
-  medium: "medium",
-  facebook: "facebook",
-  instagram: "instagram",
-  dribbble: "dribbble",
-  behance: "behance",
-  twitch: "twitch",
-)
-
-#let _profile-to-social(profile) = {
-  let network = profile.at("network", default: none)
-  if network == none { return none }
-  let key = lower(network)
-  // Normalize twitter -> x to match moderner-cv's predefined key.
-  if key == "twitter" { key = "x" }
-  let username = profile.at("username", default: none)
-  let url = profile.at("url", default: none)
-  if key in _known-social-keys and username != none {
-    return (key, username)
-  }
-  // Custom social: need an icon, a destination URL, and a body to show.
-  let dest = if url != none { url } else if username != none { username } else { return none }
-  let body = if username != none { username } else { url }
-  let icon = _network-icon.at(key, default: "link")
-  (key, (icon, dest, body))
-}
-
-#let _location-to-address(loc) = {
-  if loc == none { return none }
-  let parts = ()
-  for k in ("address", "postalCode", "city", "region", "countryCode") {
-    let v = loc.at(k, default: none)
-    if v != none and v != "" { parts.push(v) }
-  }
-  if parts.len() == 0 { none } else { parts.join(", ") }
-}
-
-#let _basics-to-header(basics) = {
-  let header = (:)
-  let name = basics.at("name", default: none)
-  if name != none { header.insert("name", name) }
-  let label = basics.at("label", default: none)
-  if label != none { header.insert("subtitle", label) }
-
-  let social = (:)
-  let phone = basics.at("phone", default: none)
-  if phone != none { social.insert("phone", phone) }
-  let email = basics.at("email", default: none)
-  if email != none { social.insert("email", email) }
-  let url = basics.at("url", default: none)
-  if url != none {
-    // moderner-cv has no top-level website key; use a custom social.
-    social.insert("website", ("link", url, url))
-  }
-  for profile in basics.at("profiles", default: ()) {
-    let entry = _profile-to-social(profile)
-    if entry != none { social.insert(entry.at(0), entry.at(1)) }
-  }
-  let addr = _location-to-address(basics.at("location", default: none))
-  if addr != none { social.insert("address", addr) }
-  header.insert("social", social)
-  header
-}
 
 // JSON Resume permits YYYY, YYYY-MM, YYYY-MM-DD. Pass through as-is —
 // the rendered date column is freeform text, not a typed date.
@@ -273,10 +196,8 @@
   parts.join()
 }
 
-// Returns `(header: <dict>, body: <content>)`. `header` is the named
-// args for `moderner-cv.with(...)`; `body` is the trailing content.
-// Split so callers can override header kwargs or stitch in custom
-// sections before rendering.
+// Returns `(header, body)`. Split so callers can override header
+// kwargs or stitch in custom sections before rendering.
 //
 // `renderers` is a dict of `(cv-entry:, cv-entry-multiline:, cv-line:)`
 // passed in by `lib.typ` — it can't be imported directly here without
@@ -289,7 +210,7 @@
     )
   }
   let resume = _parse(data, schema: resume-schema-strict)
-  let header = _basics-to-header(resume.at("basics", default: (:)))
+  let header = basics-to-header(resume.at("basics", default: (:)))
   let body = _body-from-resume(resume, renderers)
   (header: header, body: body)
 }

--- a/internal/json-resume.typ
+++ b/internal/json-resume.typ
@@ -9,21 +9,55 @@
 // caller in `lib.typ` to avoid a cyclic `#import "../lib.typ"` —
 // `lib.typ` re-exports `from-json-resume` from this file.
 
-// JSON Resume permits YYYY, YYYY-MM, YYYY-MM-DD. Pass through as-is —
-// the rendered date column is freeform text, not a typed date.
+#let _months = (
+  "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12",
+)
+
+// Iso8601 → "M/YYYY" / "YYYY", matching the template/cv.typ
+// convention (`#cv-entry(date: [6/2024 -- Present], ...)`). Defensive
+// against JSON-number years and out-of-range months — fall back to the
+// raw string rather than panic deep in render.
+#let _format-date(d) = {
+  if d == none or d == "" { return "" }
+  let s = if type(d) == str { d } else { str(d) }
+  let parts = s.split("-")
+  if parts.len() == 1 { return parts.at(0) }
+  let year = parts.at(0)
+  let mm = parts.at(1)
+  if mm.match(regex("^(0[1-9]|1[0-2])$")) != none {
+    return _months.at(int(mm) - 1) + "/" + year
+  }
+  year
+}
+
+// Open-ended ranges render as "… -- Present". A missing start with a
+// present end emits just the end (avoids a leading "-- 2024-06").
 #let _fmt-range(start-date, end-date) = {
-  let s = if start-date == none { "" } else { start-date }
-  let e = if end-date == none { "Present" } else { end-date }
-  if s == "" and e == "Present" { [] } else { [#s -- #e] }
+  let s = _format-date(start-date)
+  let e = if end-date == none or end-date == "" { "Present" } else { _format-date(end-date) }
+  if s == "" and e == "Present" { [] } else if s == "" { [#e] } else { [#s -- #e] }
 }
 
-#let _work-entries(r, items) = {
-  for w in items {
-    let date = _fmt-range(w.at("startDate", default: none), w.at("endDate", default: none))
-    let title = w.at("position", default: [])
-    let employer = w.at("name", default: [])
-    let summary = w.at("summary", default: none)
-    let highlights = w.at("highlights", default: ())
+// Empty `().join(...)` is `none` in Typst — coerce to a real string so
+// callers concatenating into content don't get unexpected blank cells.
+#let _safe-join(arr, sep) = if arr.len() == 0 { "" } else { arr.join(sep) }
+
+
+// ---- Body section emitters ----
+
+// Work-shaped sections (work / volunteer / projects) share a date
+// range + summary/highlights body. Only the heading field names differ.
+// `summary-key` is the field used for the italic-leading paragraph.
+#let _render-rich-entry(r, items, title-key, employer-key, summary-key) = {
+  for it in items {
+    let date = _fmt-range(
+      it.at("startDate", default: none),
+      it.at("endDate", default: none),
+    )
+    let title = it.at(title-key, default: [])
+    let employer = it.at(employer-key, default: [])
+    let summary = it.at(summary-key, default: none)
+    let highlights = it.at("highlights", default: ())
     let body = {
       if summary != none { text(style: "italic", summary) }
       if highlights.len() > 0 { list(..highlights) }
@@ -36,24 +70,9 @@
   }
 }
 
-#let _volunteer-entries(r, items) = {
-  for v in items {
-    let date = _fmt-range(v.at("startDate", default: none), v.at("endDate", default: none))
-    let title = v.at("position", default: [])
-    let employer = v.at("organization", default: [])
-    let summary = v.at("summary", default: none)
-    let highlights = v.at("highlights", default: ())
-    let body = {
-      if summary != none { text(style: "italic", summary) }
-      if highlights.len() > 0 { list(..highlights) }
-    }
-    if summary == none and highlights.len() == 0 {
-      (r.cv-entry)(date: date, title: title, employer: employer)
-    } else {
-      (r.cv-entry-multiline)(date: date, title: title, employer: employer, body)
-    }
-  }
-}
+#let _work-entries(r, items) = _render-rich-entry(r, items, "position", "name", "summary")
+#let _volunteer-entries(r, items) = _render-rich-entry(r, items, "position", "organization", "summary")
+#let _projects-entries(r, items) = _render-rich-entry(r, items, "name", "entity", "description")
 
 #let _education-entries(r, items) = {
   for ed in items {
@@ -73,12 +92,15 @@
   }
 }
 
-#let _awards-entries(r, items) = {
-  for a in items {
-    let date = a.at("date", default: [])
-    let title = a.at("title", default: [])
-    let employer = a.at("awarder", default: [])
-    let summary = a.at("summary", default: none)
+// Flat single-date sections (awards / certificates / publications)
+// share an `cv-entry`/`cv-entry-multiline` shape — only the field
+// names differ. `summary-key: none` for sections without a body field.
+#let _render-flat-entry(r, items, title-key, employer-key, date-key, summary-key) = {
+  for it in items {
+    let date = _format-date(it.at(date-key, default: none))
+    let title = it.at(title-key, default: [])
+    let employer = it.at(employer-key, default: [])
+    let summary = if summary-key != none { it.at(summary-key, default: none) } else { none }
     if summary == none {
       (r.cv-entry)(date: [#date], title: title, employer: employer)
     } else {
@@ -87,47 +109,9 @@
   }
 }
 
-#let _certificates-entries(r, items) = {
-  for c in items {
-    let date = c.at("date", default: [])
-    let title = c.at("name", default: [])
-    let employer = c.at("issuer", default: [])
-    (r.cv-entry)(date: [#date], title: title, employer: employer)
-  }
-}
-
-#let _publications-entries(r, items) = {
-  for p in items {
-    let date = p.at("releaseDate", default: [])
-    let title = p.at("name", default: [])
-    let employer = p.at("publisher", default: [])
-    let summary = p.at("summary", default: none)
-    if summary == none {
-      (r.cv-entry)(date: [#date], title: title, employer: employer)
-    } else {
-      (r.cv-entry-multiline)(date: [#date], title: title, employer: employer, summary)
-    }
-  }
-}
-
-#let _projects-entries(r, items) = {
-  for p in items {
-    let date = _fmt-range(p.at("startDate", default: none), p.at("endDate", default: none))
-    let title = p.at("name", default: [])
-    let employer = p.at("entity", default: [])
-    let description = p.at("description", default: none)
-    let highlights = p.at("highlights", default: ())
-    let body = {
-      if description != none { text(style: "italic", description) }
-      if highlights.len() > 0 { list(..highlights) }
-    }
-    if description == none and highlights.len() == 0 {
-      (r.cv-entry)(date: date, title: title, employer: employer)
-    } else {
-      (r.cv-entry-multiline)(date: date, title: title, employer: employer, body)
-    }
-  }
-}
+#let _awards-entries(r, items) = _render-flat-entry(r, items, "title", "awarder", "date", "summary")
+#let _certificates-entries(r, items) = _render-flat-entry(r, items, "name", "issuer", "date", none)
+#let _publications-entries(r, items) = _render-flat-entry(r, items, "name", "publisher", "releaseDate", "summary")
 
 // Skills render as `Label: kw, kw, kw` rows via cv-line so the
 // fixed left column stays consistent with the rest of the CV.
@@ -135,7 +119,7 @@
   for s in items {
     let name = s.at("name", default: [])
     let keywords = s.at("keywords", default: ())
-    (r.cv-line)(name, keywords.join(", "))
+    (r.cv-line)(name, _safe-join(keywords, ", "))
   }
 }
 
@@ -151,11 +135,7 @@
   for i in items {
     let name = i.at("name", default: [])
     let keywords = i.at("keywords", default: ())
-    if keywords.len() == 0 {
-      (r.cv-line)(name, [])
-    } else {
-      (r.cv-line)(name, keywords.join(", "))
-    }
+    (r.cv-line)(name, _safe-join(keywords, ", "))
   }
 }
 

--- a/internal/json-resume.typ
+++ b/internal/json-resume.typ
@@ -1,0 +1,295 @@
+// JSON Resume (https://jsonresume.org/schema) adapter for moderner-cv.
+// `from-json-resume` validates via @preview/gairm-import and remaps
+// to the dict shape `moderner-cv(...)` expects (header kwargs + body
+// content). The one-call `moderner-cv-from-json` wrapper lives in
+// `lib.typ`, where it can compose `moderner-cv` directly.
+
+#import "@preview/gairm-import:0.8.1": parse as _parse, resume-schema-strict
+
+// Renderer helpers (`cv-entry`, `cv-line`, …) are passed in by the
+// caller in `lib.typ` to avoid a cyclic `#import "../lib.typ"` —
+// `lib.typ` re-exports `from-json-resume` from this file.
+
+// moderner-cv's predefined `social` keys. Anything else is emitted
+// as a custom 3-tuple `(faIcon, url, body)` so the link still renders.
+#let _known-social-keys = ("phone", "email", "github", "linkedin", "x", "bluesky")
+
+// FontAwesome guesses for networks not in the predefined set. Falls
+// back to a generic "link" icon; users who care can post-process the
+// returned dict before handing it to `moderner-cv`.
+#let _network-icon = (
+  twitter: "x-twitter",
+  mastodon: "mastodon",
+  gitlab: "gitlab",
+  stackoverflow: "stack-overflow",
+  youtube: "youtube",
+  medium: "medium",
+  facebook: "facebook",
+  instagram: "instagram",
+  dribbble: "dribbble",
+  behance: "behance",
+  twitch: "twitch",
+)
+
+#let _profile-to-social(profile) = {
+  let network = profile.at("network", default: none)
+  if network == none { return none }
+  let key = lower(network)
+  // Normalize twitter -> x to match moderner-cv's predefined key.
+  if key == "twitter" { key = "x" }
+  let username = profile.at("username", default: none)
+  let url = profile.at("url", default: none)
+  if key in _known-social-keys and username != none {
+    return (key, username)
+  }
+  // Custom social: need an icon, a destination URL, and a body to show.
+  let dest = if url != none { url } else if username != none { username } else { return none }
+  let body = if username != none { username } else { url }
+  let icon = _network-icon.at(key, default: "link")
+  (key, (icon, dest, body))
+}
+
+#let _location-to-address(loc) = {
+  if loc == none { return none }
+  let parts = ()
+  for k in ("address", "postalCode", "city", "region", "countryCode") {
+    let v = loc.at(k, default: none)
+    if v != none and v != "" { parts.push(v) }
+  }
+  if parts.len() == 0 { none } else { parts.join(", ") }
+}
+
+#let _basics-to-header(basics) = {
+  let header = (:)
+  let name = basics.at("name", default: none)
+  if name != none { header.insert("name", name) }
+  let label = basics.at("label", default: none)
+  if label != none { header.insert("subtitle", label) }
+
+  let social = (:)
+  let phone = basics.at("phone", default: none)
+  if phone != none { social.insert("phone", phone) }
+  let email = basics.at("email", default: none)
+  if email != none { social.insert("email", email) }
+  let url = basics.at("url", default: none)
+  if url != none {
+    // moderner-cv has no top-level website key; use a custom social.
+    social.insert("website", ("link", url, url))
+  }
+  for profile in basics.at("profiles", default: ()) {
+    let entry = _profile-to-social(profile)
+    if entry != none { social.insert(entry.at(0), entry.at(1)) }
+  }
+  let addr = _location-to-address(basics.at("location", default: none))
+  if addr != none { social.insert("address", addr) }
+  header.insert("social", social)
+  header
+}
+
+// JSON Resume permits YYYY, YYYY-MM, YYYY-MM-DD. Pass through as-is —
+// the rendered date column is freeform text, not a typed date.
+#let _fmt-range(start-date, end-date) = {
+  let s = if start-date == none { "" } else { start-date }
+  let e = if end-date == none { "Present" } else { end-date }
+  if s == "" and e == "Present" { [] } else { [#s -- #e] }
+}
+
+#let _work-entries(r, items) = {
+  for w in items {
+    let date = _fmt-range(w.at("startDate", default: none), w.at("endDate", default: none))
+    let title = w.at("position", default: [])
+    let employer = w.at("name", default: [])
+    let summary = w.at("summary", default: none)
+    let highlights = w.at("highlights", default: ())
+    let body = {
+      if summary != none { text(style: "italic", summary) }
+      if highlights.len() > 0 { list(..highlights) }
+    }
+    if summary == none and highlights.len() == 0 {
+      (r.cv-entry)(date: date, title: title, employer: employer)
+    } else {
+      (r.cv-entry-multiline)(date: date, title: title, employer: employer, body)
+    }
+  }
+}
+
+#let _volunteer-entries(r, items) = {
+  for v in items {
+    let date = _fmt-range(v.at("startDate", default: none), v.at("endDate", default: none))
+    let title = v.at("position", default: [])
+    let employer = v.at("organization", default: [])
+    let summary = v.at("summary", default: none)
+    let highlights = v.at("highlights", default: ())
+    let body = {
+      if summary != none { text(style: "italic", summary) }
+      if highlights.len() > 0 { list(..highlights) }
+    }
+    if summary == none and highlights.len() == 0 {
+      (r.cv-entry)(date: date, title: title, employer: employer)
+    } else {
+      (r.cv-entry-multiline)(date: date, title: title, employer: employer, body)
+    }
+  }
+}
+
+#let _education-entries(r, items) = {
+  for ed in items {
+    let date = _fmt-range(ed.at("startDate", default: none), ed.at("endDate", default: none))
+    let study = ed.at("studyType", default: none)
+    let area = ed.at("area", default: none)
+    let title = if study != none and area != none {
+      [#study #area]
+    } else if study != none { [#study] } else if area != none { [#area] } else { [] }
+    let employer = ed.at("institution", default: [])
+    let score = ed.at("score", default: none)
+    if score == none {
+      (r.cv-entry)(date: date, title: title, employer: employer)
+    } else {
+      (r.cv-entry)(date: date, title: title, employer: employer)[#score]
+    }
+  }
+}
+
+#let _awards-entries(r, items) = {
+  for a in items {
+    let date = a.at("date", default: [])
+    let title = a.at("title", default: [])
+    let employer = a.at("awarder", default: [])
+    let summary = a.at("summary", default: none)
+    if summary == none {
+      (r.cv-entry)(date: [#date], title: title, employer: employer)
+    } else {
+      (r.cv-entry-multiline)(date: [#date], title: title, employer: employer, summary)
+    }
+  }
+}
+
+#let _certificates-entries(r, items) = {
+  for c in items {
+    let date = c.at("date", default: [])
+    let title = c.at("name", default: [])
+    let employer = c.at("issuer", default: [])
+    (r.cv-entry)(date: [#date], title: title, employer: employer)
+  }
+}
+
+#let _publications-entries(r, items) = {
+  for p in items {
+    let date = p.at("releaseDate", default: [])
+    let title = p.at("name", default: [])
+    let employer = p.at("publisher", default: [])
+    let summary = p.at("summary", default: none)
+    if summary == none {
+      (r.cv-entry)(date: [#date], title: title, employer: employer)
+    } else {
+      (r.cv-entry-multiline)(date: [#date], title: title, employer: employer, summary)
+    }
+  }
+}
+
+#let _projects-entries(r, items) = {
+  for p in items {
+    let date = _fmt-range(p.at("startDate", default: none), p.at("endDate", default: none))
+    let title = p.at("name", default: [])
+    let employer = p.at("entity", default: [])
+    let description = p.at("description", default: none)
+    let highlights = p.at("highlights", default: ())
+    let body = {
+      if description != none { text(style: "italic", description) }
+      if highlights.len() > 0 { list(..highlights) }
+    }
+    if description == none and highlights.len() == 0 {
+      (r.cv-entry)(date: date, title: title, employer: employer)
+    } else {
+      (r.cv-entry-multiline)(date: date, title: title, employer: employer, body)
+    }
+  }
+}
+
+// Skills render as `Label: kw, kw, kw` rows via cv-line so the
+// fixed left column stays consistent with the rest of the CV.
+#let _skills-entries(r, items) = {
+  for s in items {
+    let name = s.at("name", default: [])
+    let keywords = s.at("keywords", default: ())
+    (r.cv-line)(name, keywords.join(", "))
+  }
+}
+
+#let _languages-entries(r, items) = {
+  for l in items {
+    let name = l.at("language", default: [])
+    let level = l.at("fluency", default: [])
+    (r.cv-line)(name, level)
+  }
+}
+
+#let _interests-entries(r, items) = {
+  for i in items {
+    let name = i.at("name", default: [])
+    let keywords = i.at("keywords", default: ())
+    if keywords.len() == 0 {
+      (r.cv-line)(name, [])
+    } else {
+      (r.cv-line)(name, keywords.join(", "))
+    }
+  }
+}
+
+#let _references-entries(r, items) = {
+  for ref in items {
+    let name = ref.at("name", default: [])
+    let reference = ref.at("reference", default: [])
+    (r.cv-entry-multiline)(date: [], title: name, employer: [], reference)
+  }
+}
+
+// Section titles are baked in — JSON Resume doesn't carry display
+// names. Callers who want different headings should call
+// `from-json-resume` directly and render the body themselves.
+#let _section(title, items, render, r) = {
+  if items.len() == 0 { return [] }
+  [
+    = #title
+    #render(r, items)
+  ]
+}
+
+#let _body-from-resume(resume, r) = {
+  let summary = resume.at("basics", default: (:)).at("summary", default: none)
+  let parts = ()
+  if summary != none { parts.push([#summary]) }
+  parts.push(_section("Experience", resume.at("work", default: ()), _work-entries, r))
+  parts.push(_section("Volunteer", resume.at("volunteer", default: ()), _volunteer-entries, r))
+  parts.push(_section("Education", resume.at("education", default: ()), _education-entries, r))
+  parts.push(_section("Projects", resume.at("projects", default: ()), _projects-entries, r))
+  parts.push(_section("Awards", resume.at("awards", default: ()), _awards-entries, r))
+  parts.push(_section("Certificates", resume.at("certificates", default: ()), _certificates-entries, r))
+  parts.push(_section("Publications", resume.at("publications", default: ()), _publications-entries, r))
+  parts.push(_section("Skills", resume.at("skills", default: ()), _skills-entries, r))
+  parts.push(_section("Languages", resume.at("languages", default: ()), _languages-entries, r))
+  parts.push(_section("Interests", resume.at("interests", default: ()), _interests-entries, r))
+  parts.push(_section("References", resume.at("references", default: ()), _references-entries, r))
+  parts.join()
+}
+
+// Returns `(header: <dict>, body: <content>)`. `header` is the named
+// args for `moderner-cv.with(...)`; `body` is the trailing content.
+// Split so callers can override header kwargs or stitch in custom
+// sections before rendering.
+//
+// `renderers` is a dict of `(cv-entry:, cv-entry-multiline:, cv-line:)`
+// passed in by `lib.typ` — it can't be imported directly here without
+// creating a cyclic `#import "../lib.typ"`.
+#let from-json-resume(data, renderers: none) = {
+  if renderers == none {
+    panic(
+      "from-json-resume requires `renderers:` — a dict of `(cv-entry:, cv-entry-multiline:, cv-line:)`. "
+        + "Use `moderner-cv-from-json` for the one-call form.",
+    )
+  }
+  let resume = _parse(data, schema: resume-schema-strict)
+  let header = _basics-to-header(resume.at("basics", default: (:)))
+  let body = _body-from-resume(resume, renderers)
+  (header: header, body: body)
+}

--- a/internal/json-resume.typ
+++ b/internal/json-resume.typ
@@ -29,7 +29,9 @@
   }
   if s.match(_ISO-FULL) != none {
     let parts = s.split("-")
-    return str(int(parts.at(2))) + "/" + str(int(parts.at(1))) + "/" + parts.at(0)
+    return (
+      str(int(parts.at(2))) + "/" + str(int(parts.at(1))) + "/" + parts.at(0)
+    )
   }
   s
 }
@@ -38,8 +40,12 @@
 // present end emits just the end (avoids a leading "-- 2024-06").
 #let _fmt-range(start-date, end-date) = {
   let s = _format-date(start-date)
-  let e = if end-date == none or end-date == "" { "Present" } else { _format-date(end-date) }
-  if s == "" and e == "Present" { [] } else if s == "" { [#e] } else { [#s -- #e] }
+  let e = if end-date == none or end-date == "" { "Present" } else {
+    _format-date(end-date)
+  }
+  if s == "" and e == "Present" { [] } else if s == "" { [#e] } else {
+    [#s -- #e]
+  }
 }
 
 // Empty `().join(...)` is `none` in Typst — coerce to a real string so
@@ -108,18 +114,41 @@
   }
 }
 
-#let _work-entries(r, items) = _render-rich-entry(r, items, "position", "name", "summary")
-#let _volunteer-entries(r, items) = _render-rich-entry(r, items, "position", "organization", "summary")
-#let _projects-entries(r, items) = _render-rich-entry(r, items, "name", "entity", "description")
+#let _work-entries(r, items) = _render-rich-entry(
+  r,
+  items,
+  "position",
+  "name",
+  "summary",
+)
+#let _volunteer-entries(r, items) = _render-rich-entry(
+  r,
+  items,
+  "position",
+  "organization",
+  "summary",
+)
+#let _projects-entries(r, items) = _render-rich-entry(
+  r,
+  items,
+  "name",
+  "entity",
+  "description",
+)
 
 #let _education-entries(r, items) = {
   for ed in items {
-    let date = _fmt-range(ed.at("startDate", default: none), ed.at("endDate", default: none))
+    let date = _fmt-range(ed.at("startDate", default: none), ed.at(
+      "endDate",
+      default: none,
+    ))
     let study = ed.at("studyType", default: none)
     let area = ed.at("area", default: none)
     let title = if study != none and area != none {
       [#study #area]
-    } else if study != none { [#study] } else if area != none { [#area] } else { [] }
+    } else if study != none { [#study] } else if area != none { [#area] } else {
+      []
+    }
     let employer = ed.at("institution", default: [])
     let score = ed.at("score", default: none)
     if score == none {
@@ -139,12 +168,21 @@
 // Flat single-date sections (awards / certificates / publications)
 // share an `cv-entry`/`cv-entry-multiline` shape — only the field
 // names differ. `summary-key: none` for sections without a body field.
-#let _render-flat-entry(r, items, title-key, employer-key, date-key, summary-key) = {
+#let _render-flat-entry(
+  r,
+  items,
+  title-key,
+  employer-key,
+  date-key,
+  summary-key,
+) = {
   for it in items {
     let date = _format-date(it.at(date-key, default: none))
     let title = it.at(title-key, default: [])
     let employer = it.at(employer-key, default: [])
-    let summary = if summary-key != none { it.at(summary-key, default: none) } else { none }
+    let summary = if summary-key != none {
+      it.at(summary-key, default: none)
+    } else { none }
     if not _has-content(summary) {
       _emit-entry(r, [#date], title, employer)
     } else {
@@ -153,9 +191,30 @@
   }
 }
 
-#let _awards-entries(r, items) = _render-flat-entry(r, items, "title", "awarder", "date", "summary")
-#let _certificates-entries(r, items) = _render-flat-entry(r, items, "name", "issuer", "date", none)
-#let _publications-entries(r, items) = _render-flat-entry(r, items, "name", "publisher", "releaseDate", "summary")
+#let _awards-entries(r, items) = _render-flat-entry(
+  r,
+  items,
+  "title",
+  "awarder",
+  "date",
+  "summary",
+)
+#let _certificates-entries(r, items) = _render-flat-entry(
+  r,
+  items,
+  "name",
+  "issuer",
+  "date",
+  none,
+)
+#let _publications-entries(r, items) = _render-flat-entry(
+  r,
+  items,
+  "name",
+  "publisher",
+  "releaseDate",
+  "summary",
+)
 
 // Skills render as `Label: kw, kw, kw` rows via cv-line so the
 // fixed left column stays consistent with the rest of the CV.
@@ -206,17 +265,72 @@
   let summary = resume.at("basics", default: (:)).at("summary", default: none)
   let parts = ()
   if summary != none { parts.push([#summary]) }
-  parts.push(_section("Experience", resume.at("work", default: ()), _work-entries, r))
-  parts.push(_section("Volunteer", resume.at("volunteer", default: ()), _volunteer-entries, r))
-  parts.push(_section("Education", resume.at("education", default: ()), _education-entries, r))
-  parts.push(_section("Projects", resume.at("projects", default: ()), _projects-entries, r))
-  parts.push(_section("Awards", resume.at("awards", default: ()), _awards-entries, r))
-  parts.push(_section("Certificates", resume.at("certificates", default: ()), _certificates-entries, r))
-  parts.push(_section("Publications", resume.at("publications", default: ()), _publications-entries, r))
-  parts.push(_section("Skills", resume.at("skills", default: ()), _skills-entries, r))
-  parts.push(_section("Languages", resume.at("languages", default: ()), _languages-entries, r))
-  parts.push(_section("Interests", resume.at("interests", default: ()), _interests-entries, r))
-  parts.push(_section("References", resume.at("references", default: ()), _references-entries, r))
+  parts.push(_section(
+    "Experience",
+    resume.at("work", default: ()),
+    _work-entries,
+    r,
+  ))
+  parts.push(_section(
+    "Volunteer",
+    resume.at("volunteer", default: ()),
+    _volunteer-entries,
+    r,
+  ))
+  parts.push(_section(
+    "Education",
+    resume.at("education", default: ()),
+    _education-entries,
+    r,
+  ))
+  parts.push(_section(
+    "Projects",
+    resume.at("projects", default: ()),
+    _projects-entries,
+    r,
+  ))
+  parts.push(_section(
+    "Awards",
+    resume.at("awards", default: ()),
+    _awards-entries,
+    r,
+  ))
+  parts.push(_section(
+    "Certificates",
+    resume.at("certificates", default: ()),
+    _certificates-entries,
+    r,
+  ))
+  parts.push(_section(
+    "Publications",
+    resume.at("publications", default: ()),
+    _publications-entries,
+    r,
+  ))
+  parts.push(_section(
+    "Skills",
+    resume.at("skills", default: ()),
+    _skills-entries,
+    r,
+  ))
+  parts.push(_section(
+    "Languages",
+    resume.at("languages", default: ()),
+    _languages-entries,
+    r,
+  ))
+  parts.push(_section(
+    "Interests",
+    resume.at("interests", default: ()),
+    _interests-entries,
+    r,
+  ))
+  parts.push(_section(
+    "References",
+    resume.at("references", default: ()),
+    _references-entries,
+    r,
+  ))
   parts.join()
 }
 

--- a/internal/json-resume.typ
+++ b/internal/json-resume.typ
@@ -9,25 +9,29 @@
 // caller in `lib.typ` to avoid a cyclic `#import "../lib.typ"` —
 // `lib.typ` re-exports `from-json-resume` from this file.
 
-#let _months = (
-  "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12",
-)
+// Hoisted to module scope so the regex isn't recompiled per call.
+#let _ISO-YEAR-ONLY = regex("^\d{4}$")
+#let _ISO-YEAR-MONTH = regex("^\d{4}-(0[1-9]|1[0-2])$")
+#let _ISO-FULL = regex("^\d{4}-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01])$")
 
-// Iso8601 → "M/YYYY" / "YYYY", matching the template/cv.typ
-// convention (`#cv-entry(date: [6/2024 -- Present], ...)`). Defensive
-// against JSON-number years and out-of-range months — fall back to the
-// raw string rather than panic deep in render.
+// Iso8601 → "M/YYYY" (or "D/M/YYYY" for full dates), matching the
+// template/cv.typ convention. Non-ISO strings (e.g. `certificates.date`
+// is `str-type` only — not iso8601-validated — so users can legitimately
+// write "circa 2020" or "Spring 2023") pass through verbatim rather
+// than being mangled by partial parsing.
 #let _format-date(d) = {
   if d == none or d == "" { return "" }
   let s = if type(d) == str { d } else { str(d) }
-  let parts = s.split("-")
-  if parts.len() == 1 { return parts.at(0) }
-  let year = parts.at(0)
-  let mm = parts.at(1)
-  if mm.match(regex("^(0[1-9]|1[0-2])$")) != none {
-    return _months.at(int(mm) - 1) + "/" + year
+  if s.match(_ISO-YEAR-ONLY) != none { return s }
+  if s.match(_ISO-YEAR-MONTH) != none {
+    let parts = s.split("-")
+    return str(int(parts.at(1))) + "/" + parts.at(0)
   }
-  year
+  if s.match(_ISO-FULL) != none {
+    let parts = s.split("-")
+    return str(int(parts.at(2))) + "/" + str(int(parts.at(1))) + "/" + parts.at(0)
+  }
+  s
 }
 
 // Open-ended ranges render as "… -- Present". A missing start with a
@@ -48,6 +52,39 @@
 // Work-shaped sections (work / volunteer / projects) share a date
 // range + summary/highlights body. Only the heading field names differ.
 // `summary-key` is the field used for the italic-leading paragraph.
+// strict schema coerces JSON string values at content paths into `[#value]`,
+// so an empty string `""` becomes empty content `[]` — truthy as a value
+// but visually nothing. Treat it as absent for the multiline-vs-single
+// dispatch so we don't print a blank italic line under the title.
+#let _has-content(v) = v != none and v != [] and v != ""
+
+// lib.typ's `cv-entry` / `cv-entry-multiline` unconditionally emit
+// `emph(employer)` in the joined element list, so an empty employer
+// (e.g. `references[].name` with no organisation slot, or
+// `education[].institution` missing) leaves a dangling ", " in the
+// rendered output. Skip the emph when empty, otherwise behave
+// identically to cv-entry / cv-entry-multiline.
+#let _emit-entry(r, date, title, employer) = {
+  let elements = if _has-content(employer) {
+    (strong(title), emph(employer))
+  } else {
+    (strong(title),)
+  }
+  (r.cv-line)(date, elements.join(", "))
+}
+
+#let _emit-multiline(r, date, title, employer, body) = {
+  let elements = if _has-content(employer) {
+    (strong(title), emph(employer))
+  } else {
+    (strong(title),)
+  }
+  (r.cv-line)(
+    date,
+    elements.join(", ") + linebreak() + text(size: 0.9em, body),
+  )
+}
+
 #let _render-rich-entry(r, items, title-key, employer-key, summary-key) = {
   for it in items {
     let date = _fmt-range(
@@ -58,14 +95,15 @@
     let employer = it.at(employer-key, default: [])
     let summary = it.at(summary-key, default: none)
     let highlights = it.at("highlights", default: ())
-    let body = {
-      if summary != none { text(style: "italic", summary) }
-      if highlights.len() > 0 { list(..highlights) }
-    }
-    if summary == none and highlights.len() == 0 {
-      (r.cv-entry)(date: date, title: title, employer: employer)
+    let has-summary = _has-content(summary)
+    if not has-summary and highlights.len() == 0 {
+      _emit-entry(r, date, title, employer)
     } else {
-      (r.cv-entry-multiline)(date: date, title: title, employer: employer, body)
+      let body = {
+        if has-summary { text(style: "italic", summary) }
+        if highlights.len() > 0 { list(..highlights) }
+      }
+      _emit-multiline(r, date, title, employer, body)
     }
   }
 }
@@ -85,9 +123,15 @@
     let employer = ed.at("institution", default: [])
     let score = ed.at("score", default: none)
     if score == none {
-      (r.cv-entry)(date: date, title: title, employer: employer)
+      _emit-entry(r, date, title, employer)
     } else {
-      (r.cv-entry)(date: date, title: title, employer: employer)[#score]
+      // Score becomes an extra positional in the joined elements.
+      let elements = if _has-content(employer) {
+        (strong(title), emph(employer), [#score])
+      } else {
+        (strong(title), [#score])
+      }
+      (r.cv-line)(date, elements.join(", "))
     }
   }
 }
@@ -101,10 +145,10 @@
     let title = it.at(title-key, default: [])
     let employer = it.at(employer-key, default: [])
     let summary = if summary-key != none { it.at(summary-key, default: none) } else { none }
-    if summary == none {
-      (r.cv-entry)(date: [#date], title: title, employer: employer)
+    if not _has-content(summary) {
+      _emit-entry(r, [#date], title, employer)
     } else {
-      (r.cv-entry-multiline)(date: [#date], title: title, employer: employer, summary)
+      _emit-multiline(r, [#date], title, employer, summary)
     }
   }
 }
@@ -143,7 +187,7 @@
   for ref in items {
     let name = ref.at("name", default: [])
     let reference = ref.at("reference", default: [])
-    (r.cv-entry-multiline)(date: [], title: name, employer: [], reference)
+    _emit-multiline(r, [], name, [], reference)
   }
 }
 

--- a/lib.typ
+++ b/lib.typ
@@ -308,7 +308,11 @@
 // the body emitter.
 #let from-json-resume(data) = _from-json-resume(
   data,
-  renderers: (cv-entry: cv-entry, cv-entry-multiline: cv-entry-multiline, cv-line: cv-line),
+  renderers: (
+    cv-entry: cv-entry,
+    cv-entry-multiline: cv-entry-multiline,
+    cv-line: cv-line,
+  ),
 )
 
 // One-call form. Named args override header kwargs derived from `basics`;
@@ -340,7 +344,8 @@
       if type(v) != dictionary {
         panic(
           "moderner-cv-from-json: `social:` override must be a dictionary; got "
-            + repr(type(v)) + ". Pass `social: (github: \"…\", linkedin: \"…\")` etc.",
+            + repr(type(v))
+            + ". Pass `social: (github: \"…\", linkedin: \"…\")` etc.",
         )
       }
       header.insert("social", (..header.at("social", default: (:)), ..v))

--- a/lib.typ
+++ b/lib.typ
@@ -320,8 +320,26 @@
         + repr(rest.pos()),
     )
   }
+  let named = rest.named()
+  // The wrapper owns `body` (it composes header + body itself); a
+  // caller-supplied `body:` would collide with the trailing positional
+  // and panic with a confusing duplicate-argument error.
+  if "body" in named {
+    panic(
+      "moderner-cv-from-json controls the body. To inject custom markup, call `from-json-resume(data)` and compose `moderner-cv(...)` yourself.",
+    )
+  }
   let parts = from-json-resume(data)
+  // Merge `social:` key-by-key (rather than whole-dict replace) so a
+  // partial override doesn't silently drop the email / github / etc.
+  // fields derived from `basics`. Same for any other dict-valued kwarg.
   let header = parts.header
-  for (k, v) in rest.named() { header.insert(k, v) }
+  for (k, v) in named {
+    if k == "social" and type(v) == dictionary {
+      header.insert("social", (..header.at("social", default: (:)), ..v))
+    } else {
+      header.insert(k, v)
+    }
+  }
   moderner-cv(..header, parts.body)
 }

--- a/lib.typ
+++ b/lib.typ
@@ -300,3 +300,31 @@
     [], list(item1), list(item2),
   )
 }
+
+#import "internal/json-resume.typ": from-json-resume as _from-json-resume
+
+// `from-json-resume(data)` -> `(header: <dict>, body: <content>)`.
+// `header` is the kwargs for `moderner-cv.with(...)`; `body` is the
+// trailing content. Split so advanced users can override or extend
+// either side. The wrapper below is the one-call form.
+#let from-json-resume(data) = _from-json-resume(
+  data,
+  renderers: (cv-entry: cv-entry, cv-entry-multiline: cv-entry-multiline, cv-line: cv-line),
+)
+
+// One-call form for `resume.json` users: validates + remaps and
+// renders. Extra named args override header kwargs derived from
+// `basics` (e.g. pass `image:` or override `subtitle:`). Extra
+// positionals are rejected to catch drift from the kwarg form.
+#let moderner-cv-from-json(data, ..rest) = {
+  if rest.pos().len() > 0 {
+    panic(
+      "moderner-cv-from-json takes one positional (`data`); pass header overrides as named arguments. Got extra positionals: "
+        + repr(rest.pos()),
+    )
+  }
+  let parts = from-json-resume(data)
+  let header = parts.header
+  for (k, v) in rest.named() { header.insert(k, v) }
+  moderner-cv(..header, parts.body)
+}

--- a/lib.typ
+++ b/lib.typ
@@ -332,7 +332,8 @@
   let parts = from-json-resume(data)
   // Merge `social:` key-by-key (rather than whole-dict replace) so a
   // partial override doesn't silently drop the email / github / etc.
-  // fields derived from `basics`. Same for any other dict-valued kwarg.
+  // fields derived from `basics`. `social` is the only dict-typed kwarg
+  // on moderner-cv today; other kwargs whole-replace as expected.
   let header = parts.header
   for (k, v) in named {
     if k == "social" and type(v) == dictionary {

--- a/lib.typ
+++ b/lib.typ
@@ -336,7 +336,13 @@
   // on moderner-cv today; other kwargs whole-replace as expected.
   let header = parts.header
   for (k, v) in named {
-    if k == "social" and type(v) == dictionary {
+    if k == "social" {
+      if type(v) != dictionary {
+        panic(
+          "moderner-cv-from-json: `social:` override must be a dictionary; got "
+            + repr(type(v)) + ". Pass `social: (github: \"…\", linkedin: \"…\")` etc.",
+        )
+      }
       header.insert("social", (..header.at("social", default: (:)), ..v))
     } else {
       header.insert(k, v)

--- a/lib.typ
+++ b/lib.typ
@@ -303,19 +303,16 @@
 
 #import "internal/json-resume.typ": from-json-resume as _from-json-resume
 
-// `from-json-resume(data)` -> `(header: <dict>, body: <content>)`.
-// `header` is the kwargs for `moderner-cv.with(...)`; `body` is the
-// trailing content. Split so advanced users can override or extend
-// either side. The wrapper below is the one-call form.
+// Returns `(header, body)`. Split so advanced callers can override a
+// single header kwarg or stitch in custom sections without re-implementing
+// the body emitter.
 #let from-json-resume(data) = _from-json-resume(
   data,
   renderers: (cv-entry: cv-entry, cv-entry-multiline: cv-entry-multiline, cv-line: cv-line),
 )
 
-// One-call form for `resume.json` users: validates + remaps and
-// renders. Extra named args override header kwargs derived from
-// `basics` (e.g. pass `image:` or override `subtitle:`). Extra
-// positionals are rejected to catch drift from the kwarg form.
+// One-call form. Named args override header kwargs derived from `basics`;
+// extra positionals are rejected to catch drift from the kwarg form.
 #let moderner-cv-from-json(data, ..rest) = {
   if rest.pos().len() > 0 {
     panic(

--- a/pixi.toml
+++ b/pixi.toml
@@ -9,11 +9,15 @@ watch = "typst watch template/cv.typ --root ."
 # TODO: treat warnings as errors https://github.com/typst/typst/issues/6787
 compile = "typst compile template/cv.typ --root ."
 compile-thumbnail = { cmd = "typst compile template/cv.typ assets/thumbnail.png --root .", env = { SOURCE_DATE_EPOCH = "1767225600" } }
+test-json-resume = "typst compile tests/json_resume.typ /tmp/json_resume.pdf --root ."
+test-helpers = "typst compile tests/json_resume_helpers.typ /tmp/json_resume_helpers.pdf --root ."
 pre-commit-run = "pre-commit run -a"
 
 [dependencies]
-typst = ">=0.14"
-typstyle = ">=0.14"
+# Bumped to 0.15 along with typst.toml's `compiler` — gairm-import (pulled
+# in by internal/json-resume.typ at the top of lib.typ) requires 0.15+.
+typst = ">=0.15"
+typstyle = ">=0.15"
 font-otf-fontawesome = "*"
 typos = "*"
 pre-commit = "*"

--- a/tests/fixtures/canonical_resume.json
+++ b/tests/fixtures/canonical_resume.json
@@ -1,0 +1,92 @@
+{
+  "$schema": "https://raw.githubusercontent.com/jsonresume/resume-schema/v1.0.0/schema.json",
+  "basics": {
+    "name": "Jane Doe",
+    "label": "Snake Specialist",
+    "email": "jane.doe@example.com",
+    "phone": "+1-202-555-0117",
+    "url": "https://example.me",
+    "summary": "Herpetologist turned founder, building tools for venom research.",
+    "location": {
+      "address": "Test Street 1",
+      "postalCode": "12345",
+      "city": "Example City",
+      "countryCode": "US",
+      "region": "CA"
+    },
+    "profiles": [
+      { "network": "GitHub",   "username": "jane-doe", "url": "https://github.com/jane-doe" },
+      { "network": "LinkedIn", "username": "jane-doe", "url": "https://linkedin.com/in/jane-doe" },
+      { "network": "X",        "username": "jane_doe", "url": "https://twitter.com/jane_doe" },
+      { "network": "Mastodon", "username": "@jane@hachyderm.io", "url": "https://hachyderm.io/@jane" }
+    ]
+  },
+  "work": [
+    {
+      "name": "Cobra Collective",
+      "position": "Founder and Lead Developer",
+      "startDate": "2024-06",
+      "summary": "Bootstrapping a research collective.",
+      "highlights": [
+        "Shipped venom-tracking platform",
+        "Grew the team to five contributors"
+      ]
+    },
+    {
+      "name": "The Snake Company",
+      "position": "Snake Specialist",
+      "startDate": "2022-04",
+      "endDate": "2023-07",
+      "summary": "Field work and lab coordination."
+    }
+  ],
+  "education": [
+    {
+      "institution": "Cobra Creek College",
+      "area": "Ophiology",
+      "studyType": "M.Sc.",
+      "startDate": "2021-09",
+      "endDate": "2024-06",
+      "score": "3.9/4.0"
+    },
+    {
+      "institution": "Serpentis University",
+      "area": "Herpetology",
+      "studyType": "B.Sc.",
+      "startDate": "2018-09",
+      "endDate": "2021-06",
+      "score": "4.0/4.0"
+    }
+  ],
+  "awards": [
+    {
+      "title": "Best New Researcher",
+      "date": "2023-11",
+      "awarder": "Herpetology Society",
+      "summary": "For contributions to field research."
+    }
+  ],
+  "skills": [
+    { "name": "Languages",    "keywords": ["Python", "Rust"] },
+    { "name": "Technologies", "keywords": ["Conda", "Boa", "Rattler-build"] }
+  ],
+  "languages": [
+    { "language": "English", "fluency": "Native" },
+    { "language": "French",  "fluency": "Fluent" },
+    { "language": "Dutch",   "fluency": "Advanced" }
+  ],
+  "interests": [
+    { "name": "Snake Spotting" },
+    { "name": "Collecting Venom" }
+  ],
+  "projects": [
+    {
+      "name": "Venom Atlas",
+      "description": "Open dataset of venom compositions.",
+      "startDate": "2023-01",
+      "endDate": "2024-03",
+      "url": "https://venom-atlas.example",
+      "highlights": ["Released v1 with 200 species"]
+    }
+  ]
+}

--- a/tests/fixtures/canonical_resume.json
+++ b/tests/fixtures/canonical_resume.json
@@ -40,6 +40,15 @@
       "summary": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo."
     }
   ],
+  "volunteer": [
+    {
+      "organization": "Herpetology Outreach",
+      "position": "Workshop Lead",
+      "startDate": "2021-06",
+      "endDate": "2022-04",
+      "summary": "Ran weekend snake-identification workshops for local schools."
+    }
+  ],
   "education": [
     {
       "institution": "Cobra Creek College",

--- a/tests/fixtures/canonical_resume.json
+++ b/tests/fixtures/canonical_resume.json
@@ -70,5 +70,43 @@
   "interests": [
     { "name": "Snake Spotting" },
     { "name": "Collecting Venom" }
+  ],
+  "awards": [
+    {
+      "title": "Best New Researcher",
+      "date": "2023-11",
+      "awarder": "Herpetology Society",
+      "summary": "For contributions to field research."
+    }
+  ],
+  "certificates": [
+    {
+      "name": "Reptile Handling License",
+      "date": "2022-05",
+      "issuer": "International Herpetological Association"
+    }
+  ],
+  "publications": [
+    {
+      "name": "Venom-tracking platform design",
+      "publisher": "Cobra Collective Tech Notes",
+      "releaseDate": "2024-09",
+      "summary": "A field-portable architecture for tracking venom samples in real time."
+    }
+  ],
+  "projects": [
+    {
+      "name": "Venom Atlas",
+      "description": "Open dataset of venom compositions.",
+      "startDate": "2023-01",
+      "endDate": "2024-03",
+      "highlights": ["Released v1 with 200 species"]
+    }
+  ],
+  "references": [
+    {
+      "name": "Dr. Salazar",
+      "reference": "Excellent field judgement and willingness to handle live cobras."
+    }
   ]
 }

--- a/tests/fixtures/canonical_resume.json
+++ b/tests/fixtures/canonical_resume.json
@@ -38,6 +38,13 @@
       "startDate": "2022-04",
       "endDate": "2023-07",
       "summary": "Field work and lab coordination."
+    },
+    {
+      "name": "Viper Ventures",
+      "position": "Working Student",
+      "startDate": "2020-09",
+      "endDate": "2022-03",
+      "summary": "Husbandry support and venom-extraction logging."
     }
   ],
   "education": [

--- a/tests/fixtures/canonical_resume.json
+++ b/tests/fixtures/canonical_resume.json
@@ -2,23 +2,16 @@
   "$schema": "https://raw.githubusercontent.com/jsonresume/resume-schema/v1.0.0/schema.json",
   "basics": {
     "name": "Jane Doe",
-    "label": "Snake Specialist",
     "email": "jane.doe@example.com",
-    "phone": "+1-202-555-0117",
     "url": "https://example.me",
-    "summary": "Herpetologist turned founder, building tools for venom research.",
     "location": {
       "address": "Test Street 1",
       "postalCode": "12345",
-      "city": "Example City",
-      "countryCode": "US",
-      "region": "CA"
+      "city": "Example City"
     },
     "profiles": [
       { "network": "GitHub",   "username": "jane-doe", "url": "https://github.com/jane-doe" },
-      { "network": "LinkedIn", "username": "jane-doe", "url": "https://linkedin.com/in/jane-doe" },
-      { "network": "X",        "username": "jane_doe", "url": "https://twitter.com/jane_doe" },
-      { "network": "Mastodon", "username": "@jane@hachyderm.io", "url": "https://hachyderm.io/@jane" }
+      { "network": "LinkedIn", "username": "jane-doe", "url": "https://linkedin.com/in/jane-doe" }
     ]
   },
   "work": [
@@ -26,10 +19,10 @@
       "name": "Cobra Collective",
       "position": "Founder and Lead Developer",
       "startDate": "2024-06",
-      "summary": "Bootstrapping a research collective.",
+      "summary": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod.",
       "highlights": [
-        "Shipped venom-tracking platform",
-        "Grew the team to five contributors"
+        "Lorem ipsum dolor sit amet, consectetur adipiscing.",
+        "Lorem ipsum dolor sit."
       ]
     },
     {
@@ -37,44 +30,36 @@
       "position": "Snake Specialist",
       "startDate": "2022-04",
       "endDate": "2023-07",
-      "summary": "Field work and lab coordination."
+      "summary": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation."
     },
     {
       "name": "Viper Ventures",
       "position": "Working Student",
-      "startDate": "2020-09",
-      "endDate": "2022-03",
-      "summary": "Husbandry support and venom-extraction logging."
+      "startDate": "2022-04",
+      "endDate": "2023-07",
+      "summary": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo."
     }
   ],
   "education": [
     {
       "institution": "Cobra Creek College",
-      "area": "Ophiology",
       "studyType": "M.Sc.",
-      "startDate": "2021-09",
-      "endDate": "2024-06",
+      "area": "Ophiology",
+      "startDate": "2021",
+      "endDate": "2024",
       "score": "3.9/4.0"
     },
     {
       "institution": "Serpentis University",
-      "area": "Herpetology",
       "studyType": "B.Sc.",
-      "startDate": "2018-09",
-      "endDate": "2021-06",
+      "area": "Herpetology",
+      "startDate": "2018",
+      "endDate": "2021",
       "score": "4.0/4.0"
     }
   ],
-  "awards": [
-    {
-      "title": "Best New Researcher",
-      "date": "2023-11",
-      "awarder": "Herpetology Society",
-      "summary": "For contributions to field research."
-    }
-  ],
   "skills": [
-    { "name": "Languages",    "keywords": ["Python", "Rust"] },
+    { "name": "Languages",    "keywords": ["Python"] },
     { "name": "Technologies", "keywords": ["Conda", "Boa", "Rattler-build"] }
   ],
   "languages": [
@@ -85,15 +70,5 @@
   "interests": [
     { "name": "Snake Spotting" },
     { "name": "Collecting Venom" }
-  ],
-  "projects": [
-    {
-      "name": "Venom Atlas",
-      "description": "Open dataset of venom compositions.",
-      "startDate": "2023-01",
-      "endDate": "2024-03",
-      "url": "https://venom-atlas.example",
-      "highlights": ["Released v1 with 200 species"]
-    }
   ]
 }

--- a/tests/json_resume.typ
+++ b/tests/json_resume.typ
@@ -1,0 +1,3 @@
+#import "../lib.typ": moderner-cv-from-json
+
+#moderner-cv-from-json(json("fixtures/canonical_resume.json"))

--- a/tests/json_resume_helpers.typ
+++ b/tests/json_resume_helpers.typ
@@ -1,0 +1,91 @@
+// Unit tests for the mapping helpers in
+// `internal/json-resume-mapping.typ`. Compile this file to run:
+//
+//   typst compile tests/json_resume_helpers.typ /tmp/sink.pdf --root .
+
+#import "../internal/json-resume-mapping.typ": (
+  _profile-to-social, _location-to-address, basics-to-header,
+)
+
+
+// ---- _profile-to-social ----
+
+// Predefined keys: bare username returned.
+#assert.eq(
+  _profile-to-social((network: "GitHub", username: "jane-doe", url: "https://github.com/jane-doe")),
+  ("github", "jane-doe"),
+)
+#assert.eq(
+  _profile-to-social((network: "LinkedIn", username: "jane-doe")),
+  ("linkedin", "jane-doe"),
+)
+
+// twitter → x normalisation, since moderner-cv's predefined key is "x".
+#assert.eq(
+  _profile-to-social((network: "Twitter", username: "jane_doe")),
+  ("x", "jane_doe"),
+)
+#assert.eq(
+  _profile-to-social((network: "X", username: "jane_doe")),
+  ("x", "jane_doe"),
+)
+
+// Unknown network with a known FontAwesome icon (mastodon) →
+// custom 3-tuple. Body falls back to username when no URL.
+#assert.eq(
+  _profile-to-social((network: "Mastodon", username: "@jane@hachyderm.io", url: "https://hachyderm.io/@jane")),
+  ("mastodon", ("mastodon", "https://hachyderm.io/@jane", "@jane@hachyderm.io")),
+)
+
+// Unknown network with no FontAwesome guess → generic "link" icon.
+#assert.eq(
+  _profile-to-social((network: "ResearchGate", username: "jdoe", url: "https://researchgate.net/jdoe")),
+  ("researchgate", ("link", "https://researchgate.net/jdoe", "jdoe")),
+)
+
+// No network at all → none.
+#assert.eq(_profile-to-social((:)), none)
+// No destination at all → none.
+#assert.eq(_profile-to-social((network: "GitHub")), none)
+
+
+// ---- _location-to-address ----
+
+#assert.eq(
+  _location-to-address((
+    address: "Test Street 1",
+    postalCode: "12345",
+    city: "Example City",
+    region: "CA",
+    countryCode: "US",
+  )),
+  "Test Street 1, 12345, Example City, CA, US",
+)
+#assert.eq(_location-to-address((city: "Berlin")), "Berlin")
+#assert.eq(_location-to-address(none), none)
+#assert.eq(_location-to-address((:)), none)
+
+
+// ---- basics-to-header ----
+
+// `basics.url` has no predefined slot; surfaces as a `website` custom.
+#assert.eq(
+  basics-to-header((
+    name: "Jane Doe",
+    label: "Snake Specialist",
+    email: "jane@example.com",
+    url: "https://example.me",
+  )),
+  (
+    name: "Jane Doe",
+    subtitle: "Snake Specialist",
+    social: (
+      email: "jane@example.com",
+      website: ("link", "https://example.me", "https://example.me"),
+    ),
+  ),
+)
+
+// A small empty page so typst-compile produces a valid artifact.
+#set page(width: 5cm, height: 5cm)
+helpers ok

--- a/tests/json_resume_helpers.typ
+++ b/tests/json_resume_helpers.typ
@@ -4,7 +4,7 @@
 //   typst compile tests/json_resume_helpers.typ /tmp/sink.pdf --root .
 
 #import "../internal/json-resume-mapping.typ": (
-  _profile-to-social, _location-to-address, basics-to-header,
+  _location-to-address, _profile-to-social, basics-to-header,
 )
 
 
@@ -12,7 +12,11 @@
 
 // Predefined keys: bare username returned.
 #assert.eq(
-  _profile-to-social((network: "GitHub", username: "jane-doe", url: "https://github.com/jane-doe")),
+  _profile-to-social((
+    network: "GitHub",
+    username: "jane-doe",
+    url: "https://github.com/jane-doe",
+  )),
   ("github", "jane-doe"),
 )
 #assert.eq(
@@ -33,13 +37,24 @@
 // Unknown network with a known FontAwesome icon (mastodon) →
 // custom 3-tuple. Body falls back to username when no URL.
 #assert.eq(
-  _profile-to-social((network: "Mastodon", username: "@jane@hachyderm.io", url: "https://hachyderm.io/@jane")),
-  ("mastodon", ("mastodon", "https://hachyderm.io/@jane", "@jane@hachyderm.io")),
+  _profile-to-social((
+    network: "Mastodon",
+    username: "@jane@hachyderm.io",
+    url: "https://hachyderm.io/@jane",
+  )),
+  (
+    "mastodon",
+    ("mastodon", "https://hachyderm.io/@jane", "@jane@hachyderm.io"),
+  ),
 )
 
 // Unknown network with no FontAwesome guess → generic "link" icon.
 #assert.eq(
-  _profile-to-social((network: "ResearchGate", username: "jdoe", url: "https://researchgate.net/jdoe")),
+  _profile-to-social((
+    network: "ResearchGate",
+    username: "jdoe",
+    url: "https://researchgate.net/jdoe",
+  )),
   ("researchgate", ("link", "https://researchgate.net/jdoe", "jdoe")),
 )
 

--- a/tests/json_resume_helpers.typ
+++ b/tests/json_resume_helpers.typ
@@ -45,8 +45,18 @@
 
 // No network at all → none.
 #assert.eq(_profile-to-social((:)), none)
-// No destination at all → none.
-#assert.eq(_profile-to-social((network: "GitHub")), none)
+// Empty network string → none (would otherwise create a "" social key).
+#assert.eq(_profile-to-social((network: "", url: "https://x")), none)
+// `Phone` / `Email` networks are basics-owned slots; skip rather than
+// silently clobber `basics.phone` / `basics.email`.
+#assert.eq(_profile-to-social((network: "Phone", username: "+1")), none)
+#assert.eq(_profile-to-social((network: "Email", username: "x@y.com")), none)
+// Known network with only URL falls to custom 3-tuple, but now picks up
+// the brand icon (was previously the generic "link" icon).
+#assert.eq(
+  _profile-to-social((network: "GitHub", url: "https://github.com/jane")),
+  ("github", ("github", "https://github.com/jane", "https://github.com/jane")),
+)
 
 
 // ---- _location-to-address ----

--- a/typst.toml
+++ b/typst.toml
@@ -16,7 +16,7 @@ keywords = [
 ]
 categories = ["cv"]
 disciplines = []
-exclude = ["pixi.*", ".pixi"]
+exclude = ["pixi.*", ".pixi", "tests"]
 repository = "https://github.com/pavelzw/moderner-cv"
 
 [template]

--- a/typst.toml
+++ b/typst.toml
@@ -1,7 +1,7 @@
 [package]
 name = "moderner-cv"
 version = "0.2.1"
-compiler = "0.14.0"
+compiler = "0.15.0"
 entrypoint = "lib.typ"
 authors = ["Pavel Zwerschke <@pavelzw>"]
 license = "MIT"


### PR DESCRIPTION
## Summary

This PR adds support for importing CVs using the [JSON Resume](https://jsonresume.org/schema) schema.

While looking through the existing template's `social` dict and per-section emitters, I noticed they're already relatively close to the canonical JSON Resume structure. As a result, I thought it would be an interesting proof of concept to port one of my own JSON Resume-based CVs between different resume templates with minimal or no manual modification.

The goal is to allow users who already maintain a JSON Resume document to use moderner-cv directly without having to rewrite their data into a template-specific format.

## Motivation

JSON Resume provides a widely recognised and reusable resume schema that is supported by a number of resume builders and templates. Although the schema has some limitations and does not cover every possible use case, it offers a useful common foundation and vocabulary.

By supporting JSON Resume:

- Existing JSON Resume users can use this template immediately.
- Users are not locked into a template-specific data model.
- The project gains interoperability with a broader ecosystem of resume tooling.
- Awareness of an existing community standard is increased, potentially reducing duplicated schema-design effort.

I have followed a similar approach in the [`altacv`](https://typst.app/universe/package/altacv) Typst port, where JSON Resume compatibility has proven useful for portability between templates — and that work is where the question "could the same be done for moderner-cv?" originated.

## What's added

Two new public functions, re-exported from `lib.typ`:

- **`moderner-cv-from-json(data, ..rest)`** — one-call form. Reads the JSON, validates it, and renders a full document. Named overrides (`image:`, `subtitle:`, `lang:`, …) take precedence over what's inferred from `basics`; a caller-supplied `social:` dict is merged key-by-key into the basics-derived social map (rather than wholesale-replacing it) so partial overrides don't silently drop the JSON-derived fields.
- **`from-json-resume(data) → (header, body)`** — for users who want to override a single header field, stitch in custom sections, or skip the built-in body layout. `header` is the kwargs for `moderner-cv.with(...)`; `body` is the trailing content.

The canonical JSON Resume shape covers everything moderner-cv's template surface needs (`name` / `subtitle` / `social` map; `cv-entry` / `cv-entry-multiline` / `cv-line` body), so the adapter does not introduce any schema extensions — a vanilla `resume.json` validates and renders as-is. The `basics → social` remap and the per-section body rendering live in this package (`internal/json-resume*.typ`).

Files:

- `internal/json-resume-mapping.typ` — pure data → data mapping (`basics-to-header`, `_profile-to-social`, `_location-to-address`). Includes a single FontAwesome icon table for known and fallback networks.
- `internal/json-resume.typ` — body emitters (`_render-rich-entry` / `_render-flat-entry` cover work/volunteer/projects and awards/certificates/publications respectively), date formatting matching the template's `M/YYYY` convention, and a `from-json-resume(data, renderers: …)` whose `renderers:` dict avoids a cyclic `#import "../lib.typ"`.
- `lib.typ` — re-exports the two public entry points; `moderner-cv-from-json` lives here so it can compose `moderner-cv(...)` directly.
- `tests/fixtures/canonical_resume.json` — Jane Doe fixture mirroring the upstream `template/cv.typ`, plus the sections the template doesn't itself exercise (volunteer / projects / awards / certificates / publications / references) so every render path is covered by the smoke test.
- `tests/json_resume.typ` — integration smoke test.
- `tests/json_resume_helpers.typ` — unit assertions on the mapping helpers (twitter→x normalisation, predefined-key vs custom-3-tuple dispatch, address join, basics → header).
- `pixi.toml` — adds `test-json-resume` and `test-helpers` tasks.
- `.github/workflows/ci.yml` — wires those tasks into the existing `compile` job.
- `README.md` — new "Loading from a JSON Resume document" section.
- `typst.toml` — see compatibility section below.

## Compatibility

- No changes to the existing template-specific entry point — existing CVs continue to work unchanged.
- JSON Resume support is purely additive.
- `typst.toml`'s `compiler` is bumped from `0.14.0` to `0.15.0`, and `pixi.toml` follows suit. Reason: gairm-import relies on Typst 0.15's [`path()`](https://typst.app/docs/reference/foundations/path/) function to resolve `resume.json` relative to the caller's `.typ` file. Because `lib.typ` imports the new adapter at top level, that 0.15 requirement is effective for the whole package. Happy to revisit if you'd prefer to keep 0.14 and gate the import lazily (e.g. drop the top-level `#import` and let users do `#import "@preview/moderner-cv:..": moderner-cv-from-json` from a submodule path) — let me know.

## Testing

End-to-end testing was performed using real-world JSON Resume documents, including my own CV, to verify that data can be imported successfully and rendered correctly.

In-tree:

- `tests/json_resume.typ` compiles the Jane Doe fixture end-to-end — exercises every section the adapter supports, including the twitter→x predefined-key normalisation and the Mastodon-style custom-3-tuple fallback (well, indirectly — the integration fixture keeps to the upstream template's network set; the custom-3-tuple path is covered by the unit tests).
- `tests/json_resume_helpers.typ` runs `#assert.eq` assertions on the mapping helpers, including the new URL-scheme guard, the basics-owned-keys skip (phone/email), and the empty-network rejection.
- CI invokes both via the new `pixi run test-json-resume` and `pixi run test-helpers` tasks.

## Limitations

The canonical JSON Resume shape carries everything moderner-cv's template surface needs, so this PR introduces no schema extensions. A handful of template conventions (date format `M/YYYY`, hardcoded section titles in English) are mirrored from `template/cv.typ`; users who want different formatting can drop down to `from-json-resume(data)` and compose `moderner-cv(...)` themselves.

Feedback is very welcome, particularly on the mapping decisions and any areas where closer alignment with either schema would be beneficial.

Tracking issue on the import library: https://github.com/smur89/gairm-import/issues/81.
